### PR TITLE
use querySelector rather than getElementsByClassName

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@ window.onscroll = function() {scrollFunction()};
 function scrollFunction() {
   if (document.body.scrollTop > 50 || document.documentElement.scrollTop > 50) {
     document.getElementById("header").style.fontSize = "0.75em";
-    // document.getElementsByClassName("bighed nav dropdown").style.fontSize = "0.75em";
+    document.querySelector('.dropdown-content').style.fontSize = "1rem";
       } 
       
       else {


### PR DESCRIPTION
querySelector gets a single element whereas getElementsByClassName gets a list and calling .style on the list isn't valid (its only valid on a single element)